### PR TITLE
Fix version mismatch error in GitHub workflow

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -132,6 +132,8 @@ jobs:
     - name: Update pom.xml version
       run: |
         NEW_VERSION="${{ steps.new_version.outputs.new_version }}"
+        # Remove any existing backup files from previous runs
+        rm -f pom.xml.versionsBackup
         mvn versions:set -DnewVersion=$NEW_VERSION
         mvn versions:commit
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ logs/
 
 # PM2
 .pm2/
+
+# Maven Versions Plugin backup files
+pom.xml.versionsBackup
+pom.xml.tag
+pom.xml.releaseBackup

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
 					</jvmArguments>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.16.2</version>
+			</plugin>
 		</plugins>
 
 		<resources>


### PR DESCRIPTION
- Add Maven Versions Plugin to pom.xml build section (required for mvn versions:set command)
- Add cleanup step in workflow to remove backup files before version update
- Add Maven Versions Plugin backup file patterns to .gitignore